### PR TITLE
(공용) SignIn Component 구현 #47

### DIFF
--- a/src/component/AllergySelectPageComponent/IdCheck.css
+++ b/src/component/AllergySelectPageComponent/IdCheck.css
@@ -1,44 +1,5 @@
-.idCheck {
-    position: absolute;
-    top: 65px;
-    right: 60px;
-    font-size: 20px;
-    color: white;
+.idCheckComponent {
     display: flex;
+    justify-content: center;
     align-items: center;
-}
-
-.idCheck-box {
-    display: flex;
-    align-items: center;
-    margin-left: 10px;
-}
-
-.id-input {
-    border: 1px solid white;
-    color: white;
-    font-size: 15px;
-    margin-right: 10px;
-    padding: 5px;
-    border-radius: 5px;
-}
-
-.login-button {
-    color: white;
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 10px;
-    font-size: 15px;
-    font-weight: bold;
-    cursor: pointer;
-    background-color: red;
-}
-
-.login-button:hover {
-    background-color: #d21e1e;
-}
-
-.login-button:active {
-    background-color: #9a3c3c;
-    transform: scale(0.94);
 }

--- a/src/component/AllergySelectPageComponent/IdCheck.jsx
+++ b/src/component/AllergySelectPageComponent/IdCheck.jsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import './IdCheck.css';
+import SignInComponent from './SignInComponent';
 
-const IdCheck = ({ inputValue, setInputValue }) => {
+const IdCheck = () => {
   return (
-    <div className="idCheck">아이디가 있다면?
-      <span className="idCheck-box">
-        <input
-          className="id-input"
-          type="text"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          placeholder="아이디를 입력해주세요."
-        />
-        <button className="login-button">로그인</button>
-      </span>
+    <div className="idCheckComponent">
+      <SignInComponent />
     </div>
   );
 };

--- a/src/component/AllergySelectPageComponent/SignInComponent.css
+++ b/src/component/AllergySelectPageComponent/SignInComponent.css
@@ -1,0 +1,45 @@
+.signInComponent {
+    position: absolute;
+    top: 65px;
+    right: 60px;
+    font-size: 20px;
+    color: white;
+    display: flex;
+    align-items: center;
+}
+
+.signInBox {
+    display: flex;
+    align-items: center;
+}
+
+.custom-textfield {
+    border: 1px solid white;
+    color: white;
+    font-size: 15px;
+    margin-right: 10px;
+    padding: 5px;
+    border-radius: 5px;
+}
+
+.loginButton {
+    color: white;
+    border: none;
+    width: 100px;
+    padding: 0.5rem 1rem;
+    border-radius: 10px;
+    font-size: 15px;
+    font-weight: bold;
+    cursor: pointer;
+    background-color: red;
+    text-align: center;
+}
+
+.loginButton:hover {
+    background-color: #d21e1e;
+}
+
+.loginButton:active {
+    background-color: #9a3c3c;
+    transform: scale(0.94);
+}

--- a/src/component/AllergySelectPageComponent/SignInComponent.jsx
+++ b/src/component/AllergySelectPageComponent/SignInComponent.jsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+import './SignInComponent.css';
+import CustomTextField from '../CustomComponent/CustomTextField';
+
+const SignInComponent = () => {
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <div className="signInComponent">
+      <div className="signInBox">
+        <CustomTextField
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          size="medium"
+          backgroundColor="transparent"
+          fontColor="white"
+          fontSize="15px"
+          placeholder="아이디를 입력해주세요."
+        />
+        <button className="loginButton">로그인</button>
+      </div>
+    </div>
+  );
+};
+
+export default SignInComponent;

--- a/src/component/CustomComponent/CustomTextField.jsx
+++ b/src/component/CustomComponent/CustomTextField.jsx
@@ -9,6 +9,7 @@ const CustomTextField = ({
   backgroundColor = "white",
   fontColor = "black",
   fontSize = "16px",
+  placeholder = "",
 }) => {
   const sizeStyles = {
     small: {
@@ -33,6 +34,7 @@ const CustomTextField = ({
       className={`custom-textfield ${size}`}
       value={value}
       onChange={onChange}
+      placeholder={placeholder}
       style={{
         backgroundColor: backgroundColor,
         color: fontColor,
@@ -50,6 +52,7 @@ CustomTextField.propTypes = {
   backgroundColor: PropTypes.string,
   fontColor: PropTypes.string,
   fontSize: PropTypes.string,
+  placeholder: PropTypes.string,
 };
 
 export default CustomTextField;


### PR DESCRIPTION
1. 재형이가 구현한 CustomTextField 컴포넌트의 TextField에 placeholder 추가
2. 1번을 참고하여 로그인 시, TextField와 LoginButton이 포함된 SignInComponent 구현
3. 기존의 복잡한 IdCheck 컴포넌트를 삭제하고, 대신 2번의 공용 컴포넌트를 재사용함.

@ambition-kwon @21divcert @kjeok00 리.뷰.요.청.드.립.니.다.